### PR TITLE
Numerical accuracy tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Build NeuralAmpModelerCore loadmodel
+      - name: Build NeuralAmpModelerCore tools (loadmodel, render)
         working-directory: integration-run/NeuralAmpModelerCore
         env:
           CXX: clang++

--- a/test/_configs.py
+++ b/test/_configs.py
@@ -1,0 +1,216 @@
+"""
+Shared config definitions for WaveNet integration tests.
+
+Used by both loadmodel and numerical agreement tests.
+"""
+
+import copy as _copy
+import json as _json
+from pathlib import Path as _Path
+from typing import Any as _Any
+
+# Activations supported by both Python _activations and NeuralAmpModelerCore loadmodel.
+# (Fasttanh is C++-only; omit it since we build the model in Python.)
+LOADMODEL_ACTIVATIONS = [
+    "Tanh",
+    "Hardtanh",
+    "ReLU",
+    "LeakyReLU",
+    "PReLU",
+    "Sigmoid",
+    "SiLU",
+    "Hardswish",
+    "LeakyHardtanh",
+    "Softsign",
+    {"name": "PairBlend", "primary": "Tanh", "secondary": "Sigmoid"},
+    {"name": "PairMultiply", "primary": "Tanh", "secondary": "Sigmoid"},
+]
+
+FILM_SLOTS = (
+    "conv_pre_film",
+    "conv_post_film",
+    "input_mixin_pre_film",
+    "input_mixin_post_film",
+    "activation_pre_film",
+    "activation_post_film",
+    "layer1x1_post_film",
+    "head1x1_post_film",
+)
+
+
+def load_demonet_config() -> dict:
+    """Load demonet config (mirrors nam_full_configs/models/demonet.json)."""
+    path = _Path(__file__).resolve().parents[1] / "configs" / "demonet.json"
+    data = _json.loads(path.read_text())
+    data.pop("_notes", None)
+    data.pop("_comments", None)
+    return data
+
+
+def _condition_dsp_config() -> dict:
+    """WaveNet config with condition_dsp (different structure than demonet)."""
+    return {
+        "net": {
+            "name": "WaveNet",
+            "config": {
+                "condition_dsp": {
+                    "name": "WaveNet",
+                    "config": {
+                        "layers_configs": [
+                            {
+                                "input_size": 1,
+                                "condition_size": 1,
+                                "head_size": 2,
+                                "channels": 2,
+                                "kernel_size": 2,
+                                "dilations": [1],
+                                "activation": "Tanh",
+                            }
+                        ],
+                        "head_scale": 1.0,
+                    },
+                },
+                "layers_configs": [
+                    {
+                        "input_size": 1,
+                        "condition_size": 2,
+                        "head_size": 1,
+                        "channels": 2,
+                        "kernel_size": 2,
+                        "dilations": [1],
+                        "activation": "Tanh",
+                    }
+                ],
+                "head_scale": 1.0,
+            },
+        },
+        "optimizer": {"lr": 0.004},
+        "lr_scheduler": {"class": "ExponentialLR", "kwargs": {"gamma": 0.993}},
+    }
+
+
+def _apply_activation(config: dict, activation: _Any) -> None:
+    for layer in config["net"]["config"]["layers_configs"]:
+        layer["activation"] = activation
+
+
+def _apply_bottleneck(config: dict) -> None:
+    for layer in config["net"]["config"]["layers_configs"]:
+        layer["bottleneck"] = 2
+
+
+def _apply_groups_input(config: dict) -> None:
+    config["net"]["config"]["layers_configs"][1]["groups_input"] = 2
+
+
+def _apply_head1x1(config: dict) -> None:
+    layers_configs = config["net"]["config"]["layers_configs"]
+    head1x1_out_channels = layers_configs[0]["head_size"]
+    for layer in layers_configs:
+        layer["head_1x1_config"] = {
+            "active": True,
+            "out_channels": head1x1_out_channels,
+            "groups": 1,
+        }
+
+
+def _apply_per_layer_activations(config: dict) -> None:
+    layers_configs = config["net"]["config"]["layers_configs"]
+    per_layer_activations = ["Tanh", "ReLU"]
+    for i, layer in enumerate(layers_configs):
+        layer["activation"] = per_layer_activations[i]
+
+
+def _apply_film(config: dict, film_slot: str) -> None:
+    layers_configs = config["net"]["config"]["layers_configs"]
+    head_size = layers_configs[0]["head_size"]
+    for layer in layers_configs:
+        layer["film_params"] = {
+            film_slot: {"active": True, "shift": True, "groups": 1},
+        }
+        if film_slot == "head1x1_post_film":
+            layer["head_1x1_config"] = {
+                "active": True,
+                "out_channels": head_size,
+                "groups": 1,
+            }
+
+
+def get_config_for_variant(variant_id: str) -> dict:
+    """
+    Build a config dict for the given variant_id.
+
+    :param variant_id: One of "base", "activation_<name>", "bottleneck",
+        "groups_input", "head1x1", "per_layer_activations", "film_<slot>",
+        "condition_dsp".
+    :return: Deep copy of config, ready for module init.
+    """
+    if variant_id == "condition_dsp":
+        return _copy.deepcopy(_condition_dsp_config())
+
+    config = _copy.deepcopy(load_demonet_config())
+
+    if variant_id == "base":
+        return config
+
+    if variant_id.startswith("activation_"):
+        act_suffix = variant_id[len("activation_") :]
+        activation = None
+        for a in LOADMODEL_ACTIVATIONS:
+            if isinstance(a, dict):
+                if a.get("name") == act_suffix:
+                    activation = a
+                    break
+            elif a == act_suffix:
+                activation = a
+                break
+        if activation is None:
+            raise ValueError(f"Unknown activation variant: {variant_id}")
+        _apply_activation(config, activation)
+        return config
+
+    if variant_id == "bottleneck":
+        _apply_bottleneck(config)
+        return config
+
+    if variant_id == "groups_input":
+        _apply_groups_input(config)
+        return config
+
+    if variant_id == "head1x1":
+        _apply_head1x1(config)
+        return config
+
+    if variant_id == "per_layer_activations":
+        _apply_per_layer_activations(config)
+        return config
+
+    if variant_id.startswith("film_"):
+        film_slot = variant_id[len("film_") :]
+        if film_slot not in FILM_SLOTS:
+            raise ValueError(f"Unknown film slot: {film_slot}")
+        _apply_film(config, film_slot)
+        return config
+
+    raise ValueError(f"Unknown variant_id: {variant_id}")
+
+
+def get_all_variant_ids() -> list[str]:
+    """All variant IDs for parametrized tests."""
+    ids_ = ["base"]
+    for i, a in enumerate(LOADMODEL_ACTIVATIONS):
+        if isinstance(a, dict):
+            ids_.append(f"activation_{a.get('name', i)}")
+        else:
+            ids_.append(f"activation_{a}")
+    ids_.extend(
+        [
+            "bottleneck",
+            "groups_input",
+            "head1x1",
+            "per_layer_activations",
+            "condition_dsp",
+        ]
+    )
+    ids_.extend(f"film_{slot}" for slot in FILM_SLOTS)
+    return ids_

--- a/test/_configs.py
+++ b/test/_configs.py
@@ -63,7 +63,7 @@ def _condition_dsp_config() -> dict:
                                 "head_size": 2,
                                 "channels": 2,
                                 "kernel_size": 2,
-                                "dilations": [1],
+                                "dilations": [1, 2],
                                 "activation": "Tanh",
                             }
                         ],
@@ -77,7 +77,7 @@ def _condition_dsp_config() -> dict:
                         "head_size": 1,
                         "channels": 2,
                         "kernel_size": 2,
-                        "dilations": [1],
+                        "dilations": [1, 2],
                         "activation": "Tanh",
                     }
                 ],
@@ -87,6 +87,17 @@ def _condition_dsp_config() -> dict:
         "optimizer": {"lr": 0.004},
         "lr_scheduler": {"class": "ExponentialLR", "kwargs": {"gamma": 0.993}},
     }
+
+
+def _extended_dilations_config() -> dict:
+    """Demonet structure with more dilations to exercise the dilated conv cascade.
+    Production models use ~10 dilations; [1,2,4,8] catches receptive-field bugs
+    that minimal configs (dilations=[1] or [1,2]) might miss.
+    """
+    config = _copy.deepcopy(load_demonet_config())
+    for layer in config["net"]["config"]["layers_configs"]:
+        layer["dilations"] = [1, 2, 4, 8]
+    return config
 
 
 def _apply_activation(config: dict, activation: _Any) -> None:
@@ -147,6 +158,8 @@ def get_config_for_variant(variant_id: str) -> dict:
     """
     if variant_id == "condition_dsp":
         return _copy.deepcopy(_condition_dsp_config())
+    if variant_id == "extended_dilations":
+        return _extended_dilations_config()
 
     config = _copy.deepcopy(load_demonet_config())
 
@@ -210,6 +223,7 @@ def get_all_variant_ids() -> list[str]:
             "head1x1",
             "per_layer_activations",
             "condition_dsp",
+            "extended_dilations",
         ]
     )
     ids_.extend(f"film_{slot}" for slot in FILM_SLOTS)

--- a/test/_integration.py
+++ b/test/_integration.py
@@ -15,7 +15,9 @@ import pytest as _pytest
 _REPO_ROOT = _Path(__file__).resolve().parents[1]
 _NAM_CORE_DIR = _os.environ.get("NAM_CORE_DIR")
 _NEURAL_AMP_MODELER_CORE_DIR = (
-    _Path(_NAM_CORE_DIR) if _NAM_CORE_DIR else _REPO_ROOT.parent / "NeuralAmpModelerCore"
+    _Path(_NAM_CORE_DIR)
+    if _NAM_CORE_DIR
+    else _REPO_ROOT.parent / "NeuralAmpModelerCore"
 )
 
 
@@ -30,6 +32,20 @@ def loadmodel_exe_path() -> _Path | None:
         exe = build / "tools" / "loadmodel.exe"
     else:
         exe = build / "tools" / "loadmodel"
+    return exe if exe.exists() else None
+
+
+def render_exe_path() -> _Path | None:
+    """Path to the render executable if it exists, else None."""
+    if not _NEURAL_AMP_MODELER_CORE_DIR.exists():
+        return None
+    build = _NEURAL_AMP_MODELER_CORE_DIR / "build"
+    if not build.exists():
+        return None
+    if _sys.platform == "win32":
+        exe = build / "tools" / "render.exe"
+    else:
+        exe = build / "tools" / "render"
     return exe if exe.exists() else None
 
 
@@ -58,9 +74,47 @@ def run_loadmodel(
     )
 
 
+def run_render(
+    model_path: _Path,
+    input_wav_path: _Path,
+    output_path: _Path,
+    *,
+    timeout: float = 30.0,
+) -> _subprocess.CompletedProcess:
+    """
+    Run NeuralAmpModelerCore's render tool on a .nam model and input WAV.
+
+    :param model_path: Path to a .nam file.
+    :param input_wav_path: Path to input WAV file.
+    :param output_path: Path for output WAV file.
+    :param timeout: Seconds before the subprocess is killed.
+    :return: CompletedProcess from subprocess.run.
+    :raises: FileNotFoundError if render executable is not found.
+    """
+    exe = render_exe_path()
+    if exe is None:
+        raise FileNotFoundError(
+            "NeuralAmpModelerCore render not found: either "
+            f"{_NEURAL_AMP_MODELER_CORE_DIR!s} is missing or build/tools/render is not built."
+        )
+    return _subprocess.run(
+        [str(exe), str(model_path), str(input_wav_path), str(output_path)],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
 _has_loadmodel = loadmodel_exe_path() is not None
 
 requires_loadmodel = _pytest.mark.skipif(
     not _has_loadmodel,
     reason="NeuralAmpModelerCore not present or loadmodel tool not built",
+)
+
+_has_render = render_exe_path() is not None
+
+requires_render = _pytest.mark.skipif(
+    not _has_render,
+    reason="NeuralAmpModelerCore not present or render tool not built",
 )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,21 +1,11 @@
 """Pytest configuration and fixtures."""
 
-import json as _json
-from pathlib import Path as _Path
-
 import pytest as _pytest
 
-
-def _load_demonet_config() -> dict:
-    """Load demonet config (mirrors nam_full_configs/models/demonet.json)."""
-    path = _Path(__file__).resolve().parents[1] / "configs" / "demonet.json"
-    data = _json.loads(path.read_text())
-    data.pop("_notes", None)
-    data.pop("_comments", None)
-    return data
+from _configs import load_demonet_config
 
 
 @_pytest.fixture
 def demonet_config():
     """Demonet config for building WaveNet models."""
-    return _load_demonet_config()
+    return load_demonet_config()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,7 +1,6 @@
 """Pytest configuration and fixtures."""
 
 import pytest as _pytest
-
 from _configs import load_demonet_config
 
 

--- a/test/test_numerical_agreement.py
+++ b/test/test_numerical_agreement.py
@@ -1,0 +1,78 @@
+"""
+Numerical agreement tests: trainer (PyTorch) vs NeuralAmpModelerCore.
+
+Assert that predictions from the trainer match predictions from the core's
+render tool when given the same input.
+"""
+
+import json as _json
+from pathlib import Path as _Path
+from tempfile import TemporaryDirectory as _TemporaryDirectory
+
+import numpy as _np
+import pytest as _pytest
+
+from _integration import run_render, requires_render
+from nam.data import np_to_wav, wav_to_np
+from nam.train.lightning_module import LightningModule as _LightningModule
+
+
+def _load_demonet_config() -> dict:
+    path = _Path(__file__).resolve().parents[1] / "configs" / "demonet.json"
+    data = _json.loads(path.read_text())
+    data.pop("_notes", None)
+    data.pop("_comments", None)
+    return data
+
+
+_RTOL = 1e-5
+_ATOL = 1e-6
+
+
+@requires_render
+def test_trainer_core_numerical_agreement(demonet_config):
+    """
+    Export with include_snapshot -> render through core -> compare outputs.
+    """
+    config = _load_demonet_config()
+    module = _LightningModule.init_from_config(config)
+    module.net.sample_rate = 48000
+    sample_rate = 48000
+
+    with _TemporaryDirectory() as tmpdir:
+        outdir = _Path(tmpdir)
+        module.net.export(outdir, basename="model", include_snapshot=True)
+
+        nam_path = outdir / "model.nam"
+        assert nam_path.exists()
+
+        test_inputs_path = outdir / "test_inputs.npy"
+        test_outputs_path = outdir / "test_outputs.npy"
+        assert test_inputs_path.exists()
+        assert test_outputs_path.exists()
+
+        input_npy = _np.load(test_inputs_path)
+        expected_npy = _np.load(test_outputs_path)
+
+        input_wav_path = outdir / "input.wav"
+        np_to_wav(input_npy, input_wav_path, rate=sample_rate)
+
+        output_wav_path = outdir / "output.wav"
+        result = run_render(nam_path, input_wav_path, output_wav_path)
+
+        assert (
+            result.returncode == 0
+        ), f"render failed: stderr={result.stderr!r} stdout={result.stdout!r}"
+
+        actual = wav_to_np(output_wav_path)
+
+        expected_flat = _np.squeeze(expected_npy)
+        actual_flat = _np.squeeze(actual)
+
+        assert (
+            expected_flat.shape == actual_flat.shape
+        ), f"Shape mismatch: expected {expected_flat.shape}, got {actual_flat.shape}"
+
+        assert _np.allclose(
+            actual_flat, expected_flat, rtol=_RTOL, atol=_ATOL
+        ), f"Numerical mismatch: max |diff| = {_np.max(_np.abs(actual_flat - expected_flat))}"

--- a/test/test_numerical_agreement.py
+++ b/test/test_numerical_agreement.py
@@ -2,39 +2,42 @@
 Numerical agreement tests: trainer (PyTorch) vs NeuralAmpModelerCore.
 
 Assert that predictions from the trainer match predictions from the core's
-render tool when given the same input.
+render tool when given the same input. Parametrized over all config variants
+tested in the loadmodel tests.
 """
 
-import json as _json
 from pathlib import Path as _Path
 from tempfile import TemporaryDirectory as _TemporaryDirectory
 
 import numpy as _np
 import pytest as _pytest
 
-from _integration import run_render, requires_render
+from _configs import (
+    get_all_variant_ids as _get_all_variant_ids,
+    get_config_for_variant as _get_config_for_variant,
+)
+from _integration import run_render as _run_render, requires_render as _requires_render
 from nam.data import np_to_wav, wav_to_np
 from nam.train.lightning_module import LightningModule as _LightningModule
-
-
-def _load_demonet_config() -> dict:
-    path = _Path(__file__).resolve().parents[1] / "configs" / "demonet.json"
-    data = _json.loads(path.read_text())
-    data.pop("_notes", None)
-    data.pop("_comments", None)
-    return data
-
 
 _RTOL = 1e-5
 _ATOL = 1e-6
 
+# Variants with known small trainer/core implementation differences
+_VARIANT_TOLERANCES = {
+    "film_layer1x1_post_film": (1e-5, 0.01),
+}
 
-@requires_render
-def test_trainer_core_numerical_agreement(demonet_config):
+
+@_requires_render
+@_pytest.mark.parametrize("variant_id", _get_all_variant_ids())
+def test_trainer_core_numerical_agreement(variant_id):
     """
     Export with include_snapshot -> render through core -> compare outputs.
+
+    Runs for each config variant (activations, bottleneck, FiLM, etc.).
     """
-    config = _load_demonet_config()
+    config = _get_config_for_variant(variant_id)
     module = _LightningModule.init_from_config(config)
     module.net.sample_rate = 48000
     sample_rate = 48000
@@ -58,21 +61,25 @@ def test_trainer_core_numerical_agreement(demonet_config):
         np_to_wav(input_npy, input_wav_path, rate=sample_rate)
 
         output_wav_path = outdir / "output.wav"
-        result = run_render(nam_path, input_wav_path, output_wav_path)
+        result = _run_render(nam_path, input_wav_path, output_wav_path)
 
-        assert (
-            result.returncode == 0
-        ), f"render failed: stderr={result.stderr!r} stdout={result.stdout!r}"
+        assert result.returncode == 0, (
+            f"render failed for variant {variant_id!r}: "
+            f"stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
 
         actual = wav_to_np(output_wav_path)
 
         expected_flat = _np.squeeze(expected_npy)
         actual_flat = _np.squeeze(actual)
 
-        assert (
-            expected_flat.shape == actual_flat.shape
-        ), f"Shape mismatch: expected {expected_flat.shape}, got {actual_flat.shape}"
+        assert expected_flat.shape == actual_flat.shape, (
+            f"Shape mismatch for variant {variant_id!r}: "
+            f"expected {expected_flat.shape}, got {actual_flat.shape}"
+        )
 
-        assert _np.allclose(
-            actual_flat, expected_flat, rtol=_RTOL, atol=_ATOL
-        ), f"Numerical mismatch: max |diff| = {_np.max(_np.abs(actual_flat - expected_flat))}"
+        rtol, atol = _VARIANT_TOLERANCES.get(variant_id, (_RTOL, _ATOL))
+        assert _np.allclose(actual_flat, expected_flat, rtol=rtol, atol=atol), (
+            f"Numerical mismatch for variant {variant_id!r}: "
+            f"max |diff| = {_np.max(_np.abs(actual_flat - expected_flat))}"
+        )

--- a/test/test_numerical_agreement.py
+++ b/test/test_numerical_agreement.py
@@ -11,26 +11,30 @@ from tempfile import TemporaryDirectory as _TemporaryDirectory
 
 import numpy as _np
 import pytest as _pytest
-
-from _configs import (
-    get_all_variant_ids as _get_all_variant_ids,
-    get_config_for_variant as _get_config_for_variant,
-)
-from _integration import run_render as _run_render, requires_render as _requires_render
+from _configs import get_all_variant_ids as _get_all_variant_ids
+from _configs import get_config_for_variant as _get_config_for_variant
+from _integration import requires_render as _requires_render
+from _integration import run_render as _run_render
 from nam.data import np_to_wav, wav_to_np
 from nam.train.lightning_module import LightningModule as _LightningModule
 
 _RTOL = 1e-5
 _ATOL = 1e-6
 
-# Variants with known small trainer/core implementation differences
-_VARIANT_TOLERANCES = {
-    "film_layer1x1_post_film": (1e-5, 0.01),
-}
+
+def _variant_ids_parametrize():
+    return [
+        (
+            _pytest.param(vid, marks=_pytest.mark.xfail(reason="Issue 4"))
+            if vid == "film_layer1x1_post_film"
+            else vid
+        )
+        for vid in _get_all_variant_ids()
+    ]
 
 
 @_requires_render
-@_pytest.mark.parametrize("variant_id", _get_all_variant_ids())
+@_pytest.mark.parametrize("variant_id", _variant_ids_parametrize())
 def test_trainer_core_numerical_agreement(variant_id):
     """
     Export with include_snapshot -> render through core -> compare outputs.
@@ -78,8 +82,7 @@ def test_trainer_core_numerical_agreement(variant_id):
             f"expected {expected_flat.shape}, got {actual_flat.shape}"
         )
 
-        rtol, atol = _VARIANT_TOLERANCES.get(variant_id, (_RTOL, _ATOL))
-        assert _np.allclose(actual_flat, expected_flat, rtol=rtol, atol=atol), (
+        assert _np.allclose(actual_flat, expected_flat, rtol=_RTOL, atol=_ATOL), (
             f"Numerical mismatch for variant {variant_id!r}: "
             f"max |diff| = {_np.max(_np.abs(actual_flat - expected_flat))}"
         )

--- a/test/test_wavenet_loadmodel.py
+++ b/test/test_wavenet_loadmodel.py
@@ -5,62 +5,32 @@ Assert that models exported by the trainer (neural-amp-modeler) can be loaded
 by the core's loadmodel tool.
 """
 
-import json as _json
 from pathlib import Path as _Path
 from tempfile import TemporaryDirectory as _TemporaryDirectory
 
 import pytest as _pytest
 
-from _integration import run_loadmodel, requires_loadmodel
+from _configs import (
+    FILM_SLOTS as _FILM_SLOTS,
+    LOADMODEL_ACTIVATIONS as _LOADMODEL_ACTIVATIONS,
+    get_config_for_variant as _get_config_for_variant,
+)
+from _integration import (
+    run_loadmodel as _run_loadmodel,
+    requires_loadmodel as _requires_loadmodel,
+)
 from nam.train.lightning_module import LightningModule as _LightningModule
 
-# Activations supported by both Python _activations and NeuralAmpModelerCore loadmodel.
-# (Fasttanh is C++-only; omit it since we build the model in Python.)
-_LOADMODEL_ACTIVATIONS = [
-    "Tanh",
-    "Hardtanh",
-    "ReLU",
-    "LeakyReLU",
-    "PReLU",
-    "Sigmoid",
-    "SiLU",
-    "Hardswish",
-    "LeakyHardtanh",
-    "Softsign",
-    {"name": "PairBlend", "primary": "Tanh", "secondary": "Sigmoid"},
-    {"name": "PairMultiply", "primary": "Tanh", "secondary": "Sigmoid"},
-]
 
-_FILM_SLOTS = (
-    "conv_pre_film",
-    "conv_post_film",
-    "input_mixin_pre_film",
-    "input_mixin_post_film",
-    "activation_pre_film",
-    "activation_post_film",
-    "layer1x1_post_film",
-    "head1x1_post_film",
-)
-
-
-def _load_demonet_config() -> dict:
-    path = _Path(__file__).resolve().parents[1] / "configs" / "demonet.json"
-    data = _json.loads(path.read_text())
-    data.pop("_notes", None)
-    data.pop("_comments", None)
-    return data
-
-
-@requires_loadmodel
+@_requires_loadmodel
 @_pytest.mark.parametrize("activation", _LOADMODEL_ACTIVATIONS)
 def test_export_nam_loadmodel_can_load(demonet_config, activation):
     """
     LightningModule.init_from_config(demonet with activation replaced) -> .export()
     -> loadmodel can load the resulting .nam.
     """
-    config = _load_demonet_config()
-    for layer in config["net"]["config"]["layers_configs"]:
-        layer["activation"] = activation
+    act_id = activation if isinstance(activation, str) else activation.get("name")
+    config = _get_config_for_variant(f"activation_{act_id}")
     module = _LightningModule.init_from_config(config)
     module.net.sample_rate = 48000
     with _TemporaryDirectory() as tmpdir:
@@ -68,21 +38,19 @@ def test_export_nam_loadmodel_can_load(demonet_config, activation):
         module.net.export(outdir, basename="model")
         nam_path = outdir / "model.nam"
         assert nam_path.exists()
-        result = run_loadmodel(nam_path)
+        result = _run_loadmodel(nam_path)
         assert result.returncode == 0, (
             f"loadmodel failed for activation={activation!r}: "
             f"stderr={result.stderr!r} stdout={result.stdout!r}"
         )
 
 
-@requires_loadmodel
+@_requires_loadmodel
 def test_export_nam_loadmodel_can_load_with_bottleneck(demonet_config):
     """
     LightningModule with bottleneck -> .export() -> loadmodel can load the .nam.
     """
-    config = _load_demonet_config()
-    for layer in config["net"]["config"]["layers_configs"]:
-        layer["bottleneck"] = 2
+    config = _get_config_for_variant("bottleneck")
     module = _LightningModule.init_from_config(config)
     module.net.sample_rate = 48000
     with _TemporaryDirectory() as tmpdir:
@@ -90,21 +58,19 @@ def test_export_nam_loadmodel_can_load_with_bottleneck(demonet_config):
         module.net.export(outdir, basename="model")
         nam_path = outdir / "model.nam"
         assert nam_path.exists()
-        result = run_loadmodel(nam_path)
+        result = _run_loadmodel(nam_path)
         assert result.returncode == 0, (
             "loadmodel failed for bottleneck: "
             f"stderr={result.stderr!r} stdout={result.stdout!r}"
         )
 
 
-@requires_loadmodel
+@_requires_loadmodel
 def test_export_nam_loadmodel_can_load_with_groups_input(demonet_config):
     """
     LightningModule with groups_input=2 -> .export() -> loadmodel can load the .nam.
     """
-    config = _load_demonet_config()
-    layers_configs = config["net"]["config"]["layers_configs"]
-    layers_configs[1]["groups_input"] = 2
+    config = _get_config_for_variant("groups_input")
     module = _LightningModule.init_from_config(config)
     module.net.sample_rate = 48000
     with _TemporaryDirectory() as tmpdir:
@@ -112,27 +78,19 @@ def test_export_nam_loadmodel_can_load_with_groups_input(demonet_config):
         module.net.export(outdir, basename="model")
         nam_path = outdir / "model.nam"
         assert nam_path.exists()
-        result = run_loadmodel(nam_path)
+        result = _run_loadmodel(nam_path)
         assert result.returncode == 0, (
             "loadmodel failed for groups_input=2: "
             f"stderr={result.stderr!r} stdout={result.stdout!r}"
         )
 
 
-@requires_loadmodel
+@_requires_loadmodel
 def test_export_nam_loadmodel_can_load_with_head1x1(demonet_config):
     """
     LightningModule with head1x1 active -> .export() -> loadmodel can load the .nam.
     """
-    config = _load_demonet_config()
-    layers_configs = config["net"]["config"]["layers_configs"]
-    head1x1_out_channels = layers_configs[0]["head_size"]
-    for layer in layers_configs:
-        layer["head_1x1_config"] = {
-            "active": True,
-            "out_channels": head1x1_out_channels,
-            "groups": 1,
-        }
+    config = _get_config_for_variant("head1x1")
     module = _LightningModule.init_from_config(config)
     module.net.sample_rate = 48000
     with _TemporaryDirectory() as tmpdir:
@@ -140,24 +98,20 @@ def test_export_nam_loadmodel_can_load_with_head1x1(demonet_config):
         module.net.export(outdir, basename="model")
         nam_path = outdir / "model.nam"
         assert nam_path.exists()
-        result = run_loadmodel(nam_path)
+        result = _run_loadmodel(nam_path)
         assert result.returncode == 0, (
             "loadmodel failed for head1x1: "
             f"stderr={result.stderr!r} stdout={result.stdout!r}"
         )
 
 
-@requires_loadmodel
+@_requires_loadmodel
 def test_export_nam_loadmodel_can_load_different_activation_per_layer(demonet_config):
     """
     Same as test_export_nam_loadmodel_can_load but with a different activation
     for each layer in the layer array (loadmodel still loads the .nam).
     """
-    config = _load_demonet_config()
-    layers_configs = config["net"]["config"]["layers_configs"]
-    per_layer_activations = ["Tanh", "ReLU"]
-    for i, layer in enumerate(layers_configs):
-        layer["activation"] = per_layer_activations[i]
+    config = _get_config_for_variant("per_layer_activations")
     module = _LightningModule.init_from_config(config)
     module.net.sample_rate = 48000
     with _TemporaryDirectory() as tmpdir:
@@ -165,32 +119,20 @@ def test_export_nam_loadmodel_can_load_different_activation_per_layer(demonet_co
         module.net.export(outdir, basename="model")
         nam_path = outdir / "model.nam"
         assert nam_path.exists()
-        result = run_loadmodel(nam_path)
+        result = _run_loadmodel(nam_path)
         assert result.returncode == 0, (
             "loadmodel failed for per-layer activations: "
             f"stderr={result.stderr!r} stdout={result.stdout!r}"
         )
 
 
-@requires_loadmodel
+@_requires_loadmodel
 @_pytest.mark.parametrize("film_slot", _FILM_SLOTS)
 def test_export_nam_loadmodel_can_load_with_film(demonet_config, film_slot):
     """
     LightningModule with one FiLM slot active -> .export() -> loadmodel can load the .nam.
     """
-    config = _load_demonet_config()
-    layers_configs = config["net"]["config"]["layers_configs"]
-    head_size = layers_configs[0]["head_size"]
-    for layer in layers_configs:
-        layer["film_params"] = {
-            film_slot: {"active": True, "shift": True, "groups": 1},
-        }
-        if film_slot == "head1x1_post_film":
-            layer["head_1x1_config"] = {
-                "active": True,
-                "out_channels": head_size,
-                "groups": 1,
-            }
+    config = _get_config_for_variant(f"film_{film_slot}")
     module = _LightningModule.init_from_config(config)
     module.net.sample_rate = 48000
     with _TemporaryDirectory() as tmpdir:
@@ -198,56 +140,19 @@ def test_export_nam_loadmodel_can_load_with_film(demonet_config, film_slot):
         module.net.export(outdir, basename="model")
         nam_path = outdir / "model.nam"
         assert nam_path.exists()
-        result = run_loadmodel(nam_path)
+        result = _run_loadmodel(nam_path)
         assert result.returncode == 0, (
             f"loadmodel failed for FiLM slot {film_slot!r}: "
             f"stderr={result.stderr!r} stdout={result.stdout!r}"
         )
 
 
-@requires_loadmodel
+@_requires_loadmodel
 def test_export_nam_loadmodel_can_load_with_condition_dsp():
     """
     WaveNet with condition_dsp: export to .nam -> loadmodel can load the file.
     """
-    config = {
-        "net": {
-            "name": "WaveNet",
-            "config": {
-                "condition_dsp": {
-                    "name": "WaveNet",
-                    "config": {
-                        "layers_configs": [
-                            {
-                                "input_size": 1,
-                                "condition_size": 1,
-                                "head_size": 2,
-                                "channels": 2,
-                                "kernel_size": 2,
-                                "dilations": [1],
-                                "activation": "Tanh",
-                            }
-                        ],
-                        "head_scale": 1.0,
-                    },
-                },
-                "layers_configs": [
-                    {
-                        "input_size": 1,
-                        "condition_size": 2,
-                        "head_size": 1,
-                        "channels": 2,
-                        "kernel_size": 2,
-                        "dilations": [1],
-                        "activation": "Tanh",
-                    }
-                ],
-                "head_scale": 1.0,
-            },
-        },
-        "optimizer": {"lr": 0.004},
-        "lr_scheduler": {"class": "ExponentialLR", "kwargs": {"gamma": 0.993}},
-    }
+    config = _get_config_for_variant("condition_dsp")
     module = _LightningModule.init_from_config(config)
     module.net.sample_rate = 48000
     with _TemporaryDirectory() as tmpdir:
@@ -255,7 +160,7 @@ def test_export_nam_loadmodel_can_load_with_condition_dsp():
         module.net.export(outdir, basename="model")
         nam_path = outdir / "model.nam"
         assert nam_path.exists()
-        result = run_loadmodel(nam_path)
+        result = _run_loadmodel(nam_path)
         assert result.returncode == 0, (
             "loadmodel failed for condition_dsp: "
             f"stderr={result.stderr!r} stdout={result.stdout!r}"

--- a/test/test_wavenet_loadmodel.py
+++ b/test/test_wavenet_loadmodel.py
@@ -9,16 +9,11 @@ from pathlib import Path as _Path
 from tempfile import TemporaryDirectory as _TemporaryDirectory
 
 import pytest as _pytest
-
-from _configs import (
-    FILM_SLOTS as _FILM_SLOTS,
-    LOADMODEL_ACTIVATIONS as _LOADMODEL_ACTIVATIONS,
-    get_config_for_variant as _get_config_for_variant,
-)
-from _integration import (
-    run_loadmodel as _run_loadmodel,
-    requires_loadmodel as _requires_loadmodel,
-)
+from _configs import FILM_SLOTS as _FILM_SLOTS
+from _configs import LOADMODEL_ACTIVATIONS as _LOADMODEL_ACTIVATIONS
+from _configs import get_config_for_variant as _get_config_for_variant
+from _integration import requires_loadmodel as _requires_loadmodel
+from _integration import run_loadmodel as _run_loadmodel
 from nam.train.lightning_module import LightningModule as _LightningModule
 
 


### PR DESCRIPTION
## Funny business 🤔 

- [x] `film_layer1x1_post_film` has a difference. Look into it.--_xfail and #4 noted_
- [x] Double-check that the other cases are "real" enough to find anything funny. (E.g. more than one layer, more than one kernel)

## Summary

Implements [#1](https://github.com/Atkinson-Advanced-Modeling/NamIntegrationTests/issues/1): verify numerical agreement between the neural-amp-modeler (PyTorch) trainer and NeuralAmpModelerCore.

## Changes

- **Numerical agreement tests** (`test_numerical_agreement.py`): Export models with `include_snapshot=True`, run NeuralAmpModelerCore's render tool on the snapshot input, and assert outputs match the trainer's `test_outputs.npy` using `numpy.allclose`. Parametrized over all config variants.

- **Shared config module** (`test/_configs.py`): Centralizes `load_demonet_config`, `get_config_for_variant`, and `get_all_variant_ids` for all variants (activations, bottleneck, groups_input, head1x1, per_layer_activations, FiLM slots, condition_dsp).

- **Parametrized loadmodel tests** (`test_wavenet_loadmodel.py`): Refactored to use `_configs` and parametrize over the same variants instead of only demonet.

- **Render helpers** (`test/_integration.py`): `render_exe_path()`, `run_render()`, and `requires_render` for running the core's render tool from tests.

## Requirements

- NeuralAmpModelerCore built with the render tool (sibling checkout or `NAM_CORE_DIR`)
- `nam` package with `np_to_wav` / `wav_to_np` and `LightningModule.init_from_config`