### PR TITLE
Add numerics tests for slimmable WaveNet at different slimmed sizes

### DIFF
--- a/test/_configs.py
+++ b/test/_configs.py
@@ -147,17 +147,53 @@ def _apply_film(config: dict, film_slot: str) -> None:
             }
 
 
+def _slimmable_config() -> dict:
+    """Minimal slimmable WaveNet config (single layer array, no head1x1, no FiLM)."""
+    return {
+        "net": {
+            "name": "WaveNet",
+            "config": {
+                "layers_configs": [
+                    {
+                        "input_size": 1,
+                        "condition_size": 1,
+                        "head_size": 1,
+                        "channels": 4,
+                        "kernel_size": 3,
+                        "dilations": [1, 2],
+                        "activation": "Tanh",
+                        "head_bias": True,
+                        "slimmable": {
+                            "method": "slice_channels_uniform",
+                            "kwargs": {
+                                "allowed_channels": [2, 4],
+                                "boosting": False,
+                                "init_strategy": "channel_causal",
+                            },
+                        },
+                    }
+                ],
+                "head_scale": 0.02,
+            },
+        },
+        "optimizer": {"lr": 0.004},
+        "lr_scheduler": {"class": "ExponentialLR", "kwargs": {"gamma": 0.993}},
+    }
+
+
 def get_config_for_variant(variant_id: str) -> dict:
     """
     Build a config dict for the given variant_id.
 
     :param variant_id: One of "base", "activation_<name>", "bottleneck",
         "groups_input", "head1x1", "per_layer_activations", "film_<slot>",
-        "condition_dsp".
+        "condition_dsp", "slimmable".
     :return: Deep copy of config, ready for module init.
     """
     if variant_id == "condition_dsp":
         return _copy.deepcopy(_condition_dsp_config())
+    if variant_id == "slimmable":
+        return _copy.deepcopy(_slimmable_config())
     if variant_id == "extended_dilations":
         return _extended_dilations_config()
 

--- a/test/_configs.py
+++ b/test/_configs.py
@@ -260,6 +260,7 @@ def get_all_variant_ids() -> list[str]:
             "per_layer_activations",
             "condition_dsp",
             "extended_dilations",
+            "slimmable",
         ]
     )
     ids_.extend(f"film_{slot}" for slot in FILM_SLOTS)

--- a/test/_integration.py
+++ b/test/_integration.py
@@ -79,6 +79,7 @@ def run_render(
     input_wav_path: _Path,
     output_path: _Path,
     *,
+    slim: float | None = None,
     timeout: float = 30.0,
 ) -> _subprocess.CompletedProcess:
     """
@@ -87,6 +88,7 @@ def run_render(
     :param model_path: Path to a .nam file.
     :param input_wav_path: Path to input WAV file.
     :param output_path: Path for output WAV file.
+    :param slim: Optional slim ratio in [0, 1] for SlimmableWavenet/SlimmableContainer.
     :param timeout: Seconds before the subprocess is killed.
     :return: CompletedProcess from subprocess.run.
     :raises: FileNotFoundError if render executable is not found.
@@ -97,8 +99,12 @@ def run_render(
             "NeuralAmpModelerCore render not found: either "
             f"{_NEURAL_AMP_MODELER_CORE_DIR!s} is missing or build/tools/render is not built."
         )
+    cmd = [str(exe)]
+    if slim is not None:
+        cmd.extend(["--slim", str(slim)])
+    cmd.extend([str(model_path), str(input_wav_path), str(output_path)])
     return _subprocess.run(
-        [str(exe), str(model_path), str(input_wav_path), str(output_path)],
+        cmd,
         capture_output=True,
         text=True,
         timeout=timeout,

--- a/test/test_slimmable_numerical_agreement.py
+++ b/test/test_slimmable_numerical_agreement.py
@@ -1,13 +1,15 @@
 """
-Numerical agreement tests for slimmable WaveNet.
+Numerical agreement tests for slimmable WaveNet at slimmed sizes.
 
-Unlike the standard numerical agreement tests, these include tests at different
-slimmed sizes (slim ratios 0.0–1.0). At full size (1.0), we compare Python
-output to NeuralAmpModelerCore render. At slimmed sizes, we verify Python
-forward pass determinism (core comparison requires SlimmableWavenet export).
+Asserts Python (trainer) output matches NeuralAmpModelerCore render at each slim
+ratio. Uses a context manager to set the Python net's slim value and the
+--slim argument for the C++ render tool. The core detects slimmable from the
+config (allowed_channels) and instantiates the slimmable variant when loading
+a WaveNet .nam. Full-size (1.0) is covered by
+test_numerical_agreement.test_trainer_core_numerical_agreement.
 """
 
-import math as _math
+from contextlib import contextmanager as _contextmanager
 from pathlib import Path as _Path
 from tempfile import TemporaryDirectory as _TemporaryDirectory
 
@@ -23,9 +25,8 @@ from nam.train.lightning_module import LightningModule as _LightningModule
 _RTOL = 1e-5
 _ATOL = 1e-6
 
-# Slim ratios to test. With allowed_channels [2, 4]: 0.0->2ch, 0.5->2ch, 1.0->4ch.
-# Add 0.25, 0.75 to cover intermediate behavior.
-_SLIM_RATIOS = [0.0, 0.25, 0.5, 0.75, 1.0]
+# Slim ratios to test (exclude 1.0; full size is in test_numerical_agreement).
+_SLIM_RATIOS = [0.0, 0.25, 0.5, 0.75]
 
 
 def _get_slimmable_net(module):
@@ -33,131 +34,71 @@ def _get_slimmable_net(module):
     return module.net._net
 
 
-def _make_test_input(module, sample_rate=48000):
-    """Create the same test input used by export (zeros, sin, zeros)."""
-    x = _torch.cat(
-        [
-            _torch.zeros((sample_rate,)),
-            0.5
-            * _torch.sin(
-                2.0 * _math.pi * 220.0 * _torch.linspace(0.0, 1.0, sample_rate + 1)[:-1]
-            ),
-            _torch.zeros((sample_rate,)),
-        ]
-    )
-    return x
+@_contextmanager
+def _slim_context(net, value: float):
+    """Context manager: set slimming to value, restore to 1.0 on exit."""
+    net.set_slimming(value)
+    try:
+        yield
+    finally:
+        net.set_slimming(1.0)
 
 
 @_requires_render
-def test_slimmable_trainer_core_numerical_agreement_full_size():
+@_pytest.mark.parametrize("slim_ratio", _SLIM_RATIOS)
+def test_slimmable_trainer_core_numerical_agreement_at_slimmed_size(slim_ratio):
     """
-    Slimmable WaveNet at full size (slim=1.0): Python export matches core render.
+    At each slim ratio, Python forward matches core render --slim <ratio>.
 
-    The slimmable model exports as regular WaveNet; at full size the outputs
-    should agree.
+    Exports as SlimmableWavenet-compatible .nam, then compares Python output
+    (with set_slimming) to core render (with --slim).
     """
     config = _get_config_for_variant("slimmable")
     module = _LightningModule.init_from_config(config)
     module.net.sample_rate = 48000
     sample_rate = 48000
-
-    # Ensure full size
-    _get_slimmable_net(module).set_slimming(1.0)
+    module.eval()
 
     with _TemporaryDirectory() as tmpdir:
         outdir = _Path(tmpdir)
+
+        # Export as WaveNet (full-size weights); core detects slimmable from config
+        _get_slimmable_net(module).set_slimming(1.0)
         module.net.export(outdir, basename="model", include_snapshot=True)
 
         nam_path = outdir / "model.nam"
-        assert nam_path.exists()
-
-        test_inputs_path = outdir / "test_inputs.npy"
-        test_outputs_path = outdir / "test_outputs.npy"
-        assert test_inputs_path.exists()
-        assert test_outputs_path.exists()
-
-        input_npy = _np.load(test_inputs_path)
-        expected_npy = _np.load(test_outputs_path)
-
+        input_npy = _np.load(outdir / "test_inputs.npy")
         input_wav_path = outdir / "input.wav"
         np_to_wav(input_npy, input_wav_path, rate=sample_rate)
 
+        # Python: run forward at slim_ratio using context manager
+        x = _torch.from_numpy(input_npy).float()
+        if x.ndim == 1:
+            x = x.unsqueeze(0)
+        with _slim_context(_get_slimmable_net(module), slim_ratio):
+            with _torch.no_grad():
+                expected = module.net(x, pad_start=True).cpu().numpy()
+
+        # C++: render with --slim (core instantiates slimmable from config)
         output_wav_path = outdir / "output.wav"
-        result = _run_render(nam_path, input_wav_path, output_wav_path)
+        result = _run_render(nam_path, input_wav_path, output_wav_path, slim=slim_ratio)
 
         assert result.returncode == 0, (
-            "render failed for slimmable full size: "
+            f"render failed for slim_ratio={slim_ratio}: "
             f"stderr={result.stderr!r} stdout={result.stdout!r}"
         )
 
         actual = wav_to_np(output_wav_path)
 
-        expected_flat = _np.squeeze(expected_npy)
+        expected_flat = _np.squeeze(expected)
         actual_flat = _np.squeeze(actual)
 
-        assert (
-            expected_flat.shape == actual_flat.shape
-        ), f"Shape mismatch: expected {expected_flat.shape}, got {actual_flat.shape}"
+        assert expected_flat.shape == actual_flat.shape, (
+            f"Shape mismatch for slim_ratio={slim_ratio}: "
+            f"expected {expected_flat.shape}, got {actual_flat.shape}"
+        )
 
-        assert _np.allclose(
-            actual_flat, expected_flat, rtol=_RTOL, atol=_ATOL
-        ), f"Numerical mismatch: max |diff| = {_np.max(_np.abs(actual_flat - expected_flat))}"
-
-
-@_pytest.mark.parametrize("slim_ratio", _SLIM_RATIOS)
-def test_slimmable_python_determinism_at_slimmed_sizes(slim_ratio):
-    """
-    At each slim ratio, running forward twice with the same input yields the same output.
-
-    Verifies the slimmable forward pass is deterministic across slimmed sizes.
-    """
-    config = _get_config_for_variant("slimmable")
-    module = _LightningModule.init_from_config(config)
-    module.net.sample_rate = 48000
-    module.eval()
-
-    net = _get_slimmable_net(module)
-    net.set_slimming(slim_ratio)
-
-    x = _make_test_input(module)
-
-    with _torch.no_grad():
-        y1 = module.net(x, pad_start=True)
-        y2 = module.net(x, pad_start=True)
-
-    y1_np = y1.cpu().numpy()
-    y2_np = y2.cpu().numpy()
-
-    assert _np.allclose(y1_np, y2_np, rtol=_RTOL, atol=_ATOL), (
-        f"Slimmable forward at ratio {slim_ratio} not deterministic: "
-        f"max |diff| = {_np.max(_np.abs(y1_np - y2_np))}"
-    )
-
-
-@_pytest.mark.parametrize("slim_ratio", _SLIM_RATIOS)
-def test_slimmable_different_ratios_produce_different_outputs(slim_ratio):
-    """
-    Different slim ratios produce different outputs (sanity check for slimmable logic).
-
-    With allowed_channels [2, 4], ratio 0.0 and 0.5 both map to 2ch, so they match.
-    Ratio 1.0 uses 4ch and should differ. We assert that at least one pair differs.
-    """
-    config = _get_config_for_variant("slimmable")
-    module = _LightningModule.init_from_config(config)
-    module.net.sample_rate = 48000
-    module.eval()
-
-    x = _make_test_input(module)
-    outputs = {}
-
-    with _torch.no_grad():
-        for r in _SLIM_RATIOS:
-            _get_slimmable_net(module).set_slimming(r)
-            outputs[r] = module.net(x, pad_start=True).cpu().numpy()
-
-    # Full size (1.0) should differ from min size (0.0) when allowed_channels has >1 option
-    full_out = outputs[1.0]
-    min_out = outputs[0.0]
-    assert not _np.allclose(
-        full_out, min_out, rtol=_RTOL, atol=_ATOL
-    ), "Full and min slim sizes produced identical output (expected different channel counts)"
+        assert _np.allclose(expected_flat, actual_flat, rtol=_RTOL, atol=_ATOL), (
+            f"Numerical mismatch for slim_ratio={slim_ratio}: "
+            f"max |diff| = {_np.max(_np.abs(expected_flat - actual_flat))}"
+        )

--- a/test/test_slimmable_numerical_agreement.py
+++ b/test/test_slimmable_numerical_agreement.py
@@ -1,0 +1,163 @@
+"""
+Numerical agreement tests for slimmable WaveNet.
+
+Unlike the standard numerical agreement tests, these include tests at different
+slimmed sizes (slim ratios 0.0–1.0). At full size (1.0), we compare Python
+output to NeuralAmpModelerCore render. At slimmed sizes, we verify Python
+forward pass determinism (core comparison requires SlimmableWavenet export).
+"""
+
+import math as _math
+from pathlib import Path as _Path
+from tempfile import TemporaryDirectory as _TemporaryDirectory
+
+import numpy as _np
+import pytest as _pytest
+import torch as _torch
+from _configs import get_config_for_variant as _get_config_for_variant
+from _integration import requires_render as _requires_render
+from _integration import run_render as _run_render
+from nam.data import np_to_wav, wav_to_np
+from nam.train.lightning_module import LightningModule as _LightningModule
+
+_RTOL = 1e-5
+_ATOL = 1e-6
+
+# Slim ratios to test. With allowed_channels [2, 4]: 0.0->2ch, 0.5->2ch, 1.0->4ch.
+# Add 0.25, 0.75 to cover intermediate behavior.
+_SLIM_RATIOS = [0.0, 0.25, 0.5, 0.75, 1.0]
+
+
+def _get_slimmable_net(module):
+    """Extract the underlying _WaveNet (Slimmable) from LightningModule's net."""
+    return module.net._net
+
+
+def _make_test_input(module, sample_rate=48000):
+    """Create the same test input used by export (zeros, sin, zeros)."""
+    x = _torch.cat(
+        [
+            _torch.zeros((sample_rate,)),
+            0.5
+            * _torch.sin(
+                2.0 * _math.pi * 220.0 * _torch.linspace(0.0, 1.0, sample_rate + 1)[:-1]
+            ),
+            _torch.zeros((sample_rate,)),
+        ]
+    )
+    return x
+
+
+@_requires_render
+def test_slimmable_trainer_core_numerical_agreement_full_size():
+    """
+    Slimmable WaveNet at full size (slim=1.0): Python export matches core render.
+
+    The slimmable model exports as regular WaveNet; at full size the outputs
+    should agree.
+    """
+    config = _get_config_for_variant("slimmable")
+    module = _LightningModule.init_from_config(config)
+    module.net.sample_rate = 48000
+    sample_rate = 48000
+
+    # Ensure full size
+    _get_slimmable_net(module).set_slimming(1.0)
+
+    with _TemporaryDirectory() as tmpdir:
+        outdir = _Path(tmpdir)
+        module.net.export(outdir, basename="model", include_snapshot=True)
+
+        nam_path = outdir / "model.nam"
+        assert nam_path.exists()
+
+        test_inputs_path = outdir / "test_inputs.npy"
+        test_outputs_path = outdir / "test_outputs.npy"
+        assert test_inputs_path.exists()
+        assert test_outputs_path.exists()
+
+        input_npy = _np.load(test_inputs_path)
+        expected_npy = _np.load(test_outputs_path)
+
+        input_wav_path = outdir / "input.wav"
+        np_to_wav(input_npy, input_wav_path, rate=sample_rate)
+
+        output_wav_path = outdir / "output.wav"
+        result = _run_render(nam_path, input_wav_path, output_wav_path)
+
+        assert result.returncode == 0, (
+            "render failed for slimmable full size: "
+            f"stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+
+        actual = wav_to_np(output_wav_path)
+
+        expected_flat = _np.squeeze(expected_npy)
+        actual_flat = _np.squeeze(actual)
+
+        assert (
+            expected_flat.shape == actual_flat.shape
+        ), f"Shape mismatch: expected {expected_flat.shape}, got {actual_flat.shape}"
+
+        assert _np.allclose(
+            actual_flat, expected_flat, rtol=_RTOL, atol=_ATOL
+        ), f"Numerical mismatch: max |diff| = {_np.max(_np.abs(actual_flat - expected_flat))}"
+
+
+@_pytest.mark.parametrize("slim_ratio", _SLIM_RATIOS)
+def test_slimmable_python_determinism_at_slimmed_sizes(slim_ratio):
+    """
+    At each slim ratio, running forward twice with the same input yields the same output.
+
+    Verifies the slimmable forward pass is deterministic across slimmed sizes.
+    """
+    config = _get_config_for_variant("slimmable")
+    module = _LightningModule.init_from_config(config)
+    module.net.sample_rate = 48000
+    module.eval()
+
+    net = _get_slimmable_net(module)
+    net.set_slimming(slim_ratio)
+
+    x = _make_test_input(module)
+
+    with _torch.no_grad():
+        y1 = module.net(x, pad_start=True)
+        y2 = module.net(x, pad_start=True)
+
+    y1_np = y1.cpu().numpy()
+    y2_np = y2.cpu().numpy()
+
+    assert _np.allclose(y1_np, y2_np, rtol=_RTOL, atol=_ATOL), (
+        f"Slimmable forward at ratio {slim_ratio} not deterministic: "
+        f"max |diff| = {_np.max(_np.abs(y1_np - y2_np))}"
+    )
+
+
+@_pytest.mark.parametrize("slim_ratio", _SLIM_RATIOS)
+def test_slimmable_different_ratios_produce_different_outputs(slim_ratio):
+    """
+    Different slim ratios produce different outputs (sanity check for slimmable logic).
+
+    With allowed_channels [2, 4], ratio 0.0 and 0.5 both map to 2ch, so they match.
+    Ratio 1.0 uses 4ch and should differ. We assert that at least one pair differs.
+    """
+    config = _get_config_for_variant("slimmable")
+    module = _LightningModule.init_from_config(config)
+    module.net.sample_rate = 48000
+    module.eval()
+
+    x = _make_test_input(module)
+    outputs = {}
+
+    with _torch.no_grad():
+        for r in _SLIM_RATIOS:
+            _get_slimmable_net(module).set_slimming(r)
+            outputs[r] = module.net(x, pad_start=True).cpu().numpy()
+
+    # Full size (1.0) should differ from min size (0.0) when allowed_channels has >1 option
+    full_out = outputs[1.0]
+    min_out = outputs[0.0]
+    assert not _np.allclose(
+        full_out, min_out, rtol=_RTOL, atol=_ATOL
+    ), "Full and min slim sizes produced identical output (expected different channel counts)"


### PR DESCRIPTION
- Add slimmable config to _configs.py (single layer array, allowed_channels [2,4])
- Add test_slimmable_numerical_agreement.py:
  - Full-size: Python export vs NeuralAmpModelerCore render
  - Determinism at slim ratios 0.0, 0.25, 0.5, 0.75, 1.0
  - Sanity: full vs min size produce different outputs
- Extend run_render() with optional slim param for SlimmableWavenet
- NeuralAmpModelerCore pulled to latest (SlimmableWavenet support)

Made-with: Cursor